### PR TITLE
Fix issue 2 expiration filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -559,7 +559,6 @@ func ReqSubmissionHandler(req_chan chan ReqSubmission, close_chan chan CloseSubm
 					panic(err)
 				}
 			} else {
-				//fmt.Errorf("notification error: %s", err.Error())
 				panic(err)
 			}
 			mu.Lock()

--- a/main.go
+++ b/main.go
@@ -559,6 +559,7 @@ func ReqSubmissionHandler(req_chan chan ReqSubmission, close_chan chan CloseSubm
 					panic(err)
 				}
 			} else {
+				//fmt.Errorf("notification error: %s", err.Error())
 				panic(err)
 			}
 			mu.Lock()

--- a/storage.go
+++ b/storage.go
@@ -175,6 +175,17 @@ CREATE TRIGGER ephemeral_trigger BEFORE INSERT ON db1 FOR EACH ROW EXECUTE FUNCT
 CREATE TRIGGER expiration_trigger BEFORE INSERT ON db1 FOR EACH ROW EXECUTE FUNCTION expiration_submission();
 CREATE TRIGGER param_replaceable_trigger BEFORE INSERT ON db1 FOR EACH ROW EXECUTE FUNCTION param_replaceable_submission();
 CREATE TRIGGER submission_trigger AFTER INSERT ON db1 FOR EACH ROW EXECUTE FUNCTION notify_submission();
+
+DO $$
+DECLARE
+	column_type text;
+BEGIN
+	SELECT data_type INTO column_type FROM information_schema.columns WHERE table_name='db1' AND column_name='expiration';
+
+	IF column_type='integer' THEN
+		ALTER TABLE db1 ALTER COLUMN expiration TYPE bigint USING expiration::bigint;
+	END IF;
+END $$;
 `)
 	return dbpool, err
 }

--- a/storage.go
+++ b/storage.go
@@ -91,7 +91,7 @@ CREATE TABLE IF NOT EXISTS db1 (
   etags text[],
   ptags text[],
   dtag text,
-  expiration integer,
+  expiration bigint,
   gtags text[],
   raw json
 );


### PR DESCRIPTION
3 commits:
1. the initial change of expiration from integer to bigint and a snafu where I started testing issue #9 in the wrong branch.
2. added the section to update an existing table's column to bigint
3. removed the snafu comment from 1.

I don't see anywhere in the code that any int is explicitly declared smaller than 64 bytes. However, according to [the documentation](https://www.postgresql.org/docs/9.1/datatype-numeric.html) the size of integer in the postgres is 4 bytes, which lines up with the error. I've changed that value in the database creation from an `integer` to a `bigint` to account for the difference and added a block in the InitStorage() function to retroactively update tables that are using integer to prevent having to recreate.